### PR TITLE
Change class name

### DIFF
--- a/colorstreak/logger.py
+++ b/colorstreak/logger.py
@@ -1,6 +1,6 @@
-class log:
+class Logger:
     """
-    Clase para manejar logs con colores, con métodos accesibles directamente como log.info(), log.warning(), etc.
+    Clase para manejar logs con colores, con métodos accesibles directamente como Logger.info(), Logger.warning(), etc.
     """
     COLORS = {
         "debug": "\033[92m",     # Green
@@ -16,25 +16,25 @@ class log:
         """
         Método interno para imprimir mensajes con colores.
         """
-        color = log.COLORS.get(level, log.RESET)
-        print(f"{color}[{level.upper()}] {message}{log.RESET}")
+        color = Logger.COLORS.get(level, Logger.RESET)
+        print(f"{color}[{level.upper()}] {message}{Logger.RESET}")
 
     @staticmethod
     def debug(message):
-        log._print(message, "debug")
+        Logger._print(message, "debug")
 
     @staticmethod
     def info(message):
-        log._print(message, "info")
+        Logger._print(message, "info")
 
     @staticmethod
     def warning(message):
-        log._print(message, "warning")
+        Logger._print(message, "warning")
 
     @staticmethod
     def error(message):
-        log._print(message, "error")
+        Logger._print(message, "error")
 
     @staticmethod
     def library(message):
-        log._print(message, "library")
+        Logger._print(message, "library")

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-from colorlogterminal import log
+from colorlogterminal import Logger
 
 
 Logger.debug("This is a debug message")

--- a/test.py
+++ b/test.py
@@ -1,8 +1,8 @@
 from colorlogterminal import log
 
 
-log.debug("This is a debug message")
-log.info("This is an info message")
-log.warning("This is a warning message")
-log.error("This is an error message")
-log.deprecated("This is a deprecated message")
+Logger.debug("This is a debug message")
+Logger.info("This is an info message")
+Logger.warning("This is a warning message")
+Logger.error("This is an error message")
+Logger.deprecated("This is a deprecated message")


### PR DESCRIPTION
Replaces "log" with "Logger" for class name, along examples of use in test.py